### PR TITLE
Add Cgroup Manager interface and Libcontainer Implementation

### DIFF
--- a/pkg/kubelet/cm/cgroupManager_mock.go
+++ b/pkg/kubelet/cm/cgroupManager_mock.go
@@ -1,0 +1,45 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// MockCgroupManager is a mock object which implements the cm.CgroupManager interface
+type MockCgroupManager struct {
+	mock.Mock
+}
+
+// Make sure that MockLibcontainerManager implements CgroupManager interface
+var _ CgroupManager = &MockCgroupManager{}
+
+func (m *MockCgroupManager) Update(cgroupConfig *CgroupConfig) error {
+	args := m.Called(cgroupConfig)
+	return args.Error(0)
+}
+func (m *MockCgroupManager) Destroy() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockCgroupManager) Create(cgroupConfig *CgroupConfig) error {
+	args := m.Called(cgroupConfig)
+	return args.Error(0)
+}

--- a/pkg/kubelet/cm/cgroup_manager.go
+++ b/pkg/kubelet/cm/cgroup_manager.go
@@ -1,0 +1,104 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// libcontainerCgroupManager implements CgroupManager interface.
+// It Uses the Libcontainer raw fs cgroup manager for cgroup management.
+type libcontainerCgroupManager struct {
+	// Libcontainer raw fs cgroup manager.
+	fsCgroupManager cgroups.Manager
+}
+
+// Make sure that libcontainerCgroupManager implements the CgroupManager interface
+var _ CgroupManager = &libcontainerCgroupManager{}
+
+// Returns libcontainer's cgroups.config{} struct given the general cgroupConfig
+func getLibcontainerCgroupConfig(cgroupConfig *CgroupConfig) *configs.Cgroup {
+	// Extract the cgroup resource parameters
+	resourceConfig := cgroupConfig.ResourceParameters
+	resources := &configs.Resources{}
+	// skip the parameter if its a zero value
+	if resourceConfig.Memory != 0 {
+		resources.Memory = resourceConfig.Memory
+	}
+	if resourceConfig.CpuShares != 0 {
+		resources.CpuShares = resourceConfig.CpuShares
+	}
+	if resourceConfig.CpuQuota != 0 {
+		resources.CpuQuota = resourceConfig.CpuQuota
+	}
+	// Get the configs.Cgroup object
+	cgroupLibcontainer := &configs.Cgroup{
+		Parent:    cgroupConfig.Parent,
+		Name:      cgroupConfig.Name,
+		Resources: resources,
+	}
+	return cgroupLibcontainer
+}
+
+// Factory Method that returns a configured CgroupManager
+func NewLibcontainerCgroupManager(cgroupConfig *CgroupConfig) *libcontainerCgroupManager {
+	libcontainerCgroupConfig := getLibcontainerCgroupConfig(cgroupConfig)
+	return &libcontainerCgroupManager{
+		fsCgroupManager: &fs.Manager{
+			Cgroups: libcontainerCgroupConfig,
+		},
+	}
+}
+
+// 'Destroy' destroys the associated cgroup set
+func (m *libcontainerCgroupManager) Destroy() error {
+	if err := m.fsCgroupManager.Destroy(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// 'Update' updates the cgroup set with the specified Cgroup Configuration
+func (m *libcontainerCgroupManager) Update(cgroupConfig *CgroupConfig) error {
+	libcontainerCgroupConfig := getLibcontainerCgroupConfig(cgroupConfig)
+	config := &configs.Config{
+		Cgroups: libcontainerCgroupConfig,
+	}
+	if err := m.fsCgroupManager.Set(config); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create creates the cgroup
+func (m *libcontainerCgroupManager) Create(cgroupConfig *CgroupConfig) error {
+	libcontainerCgroupConfig := getLibcontainerCgroupConfig(cgroupConfig)
+	config := &configs.Config{
+		Cgroups: libcontainerCgroupConfig,
+	}
+	if err := m.fsCgroupManager.Apply(0); err != nil {
+		return err
+	}
+	if err := m.fsCgroupManager.Set(config); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kubelet/cm/cgroup_manager_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_test.go
@@ -1,0 +1,94 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cm
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+func NewMockLibcontainerManager(mockObject *MockLibcontainerManager) *libcontainerCgroupManager {
+	return &libcontainerCgroupManager{
+		fsCgroupManager: mockObject,
+	}
+}
+
+func TestLibcontainerCgroupManager_Create(t *testing.T) {
+	mockObject := &MockLibcontainerManager{}
+	libcontainerConfig := &configs.Config{
+		Cgroups: &configs.Cgroup{
+			Name:   "foo",
+			Parent: "/",
+			Resources: &configs.Resources{
+				Memory:    31457280,
+				CpuQuota:  1000,
+				CpuShares: 2,
+			},
+		},
+	}
+	//Setup expectations
+	mockObject.On("Set", libcontainerConfig).Return(nil)
+	mockObject.On("Apply", 0).Return(nil)
+	// Call function that uses the mockObject
+
+	libcontainerManagerMock := NewMockLibcontainerManager(mockObject)
+	cgroupConfig := &CgroupConfig{
+		Name:   "foo",
+		Parent: "/",
+		ResourceParameters: &ResourceConfig{
+			Memory:    31457280,
+			CpuQuota:  1000,
+			CpuShares: 2,
+		},
+	}
+	libcontainerManagerMock.Create(cgroupConfig)
+	mockObject.AssertExpectations(t)
+}
+
+func TestLibcontainerCgroupManager_Update(t *testing.T) {
+	mockObject := &MockLibcontainerManager{}
+	libcontainerConfig := &configs.Config{
+		Cgroups: &configs.Cgroup{
+			Name:   "foo",
+			Parent: "/",
+			Resources: &configs.Resources{
+				Memory:    31457280,
+				CpuQuota:  1000,
+				CpuShares: 2,
+			},
+		},
+	}
+	//Setup expectations
+	mockObject.On("Set", libcontainerConfig).Return(nil)
+	mockObject.On("Apply", 0).Return(nil)
+	// Call function that uses the mockObject
+
+	libcontainerManagerMock := NewMockLibcontainerManager(mockObject)
+	cgroupConfig := &CgroupConfig{
+		Name:   "foo",
+		Parent: "/",
+		ResourceParameters: &ResourceConfig{
+			Memory:    31457280,
+			CpuQuota:  1000,
+			CpuShares: 2,
+		},
+	}
+	libcontainerManagerMock.Create(cgroupConfig)
+	mockObject.AssertExpectations(t)
+}

--- a/pkg/kubelet/cm/libcontainer_manager_mock.go
+++ b/pkg/kubelet/cm/libcontainer_manager_mock.go
@@ -1,0 +1,76 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"github.com/opencontainers/runc/libcontainer/configs"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockLibcontainerManager is a mock object which implements the Libcontainer
+// Cgroup.Manager interface.
+type MockLibcontainerManager struct {
+	mock.Mock
+	Cgroups *configs.Cgroup
+}
+
+// Make sure that MockLibcontainerManager implements cgroups.Manager interface
+var _ cgroups.Manager = &MockLibcontainerManager{}
+
+func (m *MockLibcontainerManager) Apply(pid int) error {
+	args := m.Called(pid)
+	return args.Error(0)
+}
+
+func (m *MockLibcontainerManager) Destroy() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockLibcontainerManager) GetPaths() map[string]string {
+	args := m.Called()
+	return args.Get(0).(map[string]string)
+}
+
+func (m *MockLibcontainerManager) GetStats() (*cgroups.Stats, error) {
+	args := m.Called()
+	return args.Get(0).(*cgroups.Stats), args.Error(1)
+}
+
+func (m *MockLibcontainerManager) Set(container *configs.Config) error {
+	args := m.Called(container)
+	return args.Error(0)
+}
+
+func (m *MockLibcontainerManager) Freeze(state configs.FreezerState) error {
+	args := m.Called(state)
+	return args.Error(0)
+}
+
+func (m *MockLibcontainerManager) GetPids() ([]int, error) {
+	args := m.Called()
+	return args.Get(0).([]int), args.Error(1)
+}
+
+func (m *MockLibcontainerManager) GetAllPids() ([]int, error) {
+	args := m.Called()
+	return args.Get(0).([]int), args.Error(1)
+}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -1,0 +1,65 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+// QosClass defines the supported QoS classes of Pods/Containers.
+type QosClass string
+
+const (
+	// GuaranteedQoS is the Guaranteed QoS class.
+	GuaranteedQoS = "Guaranteed"
+	// BurstableQoS is the Burstable QoS class.
+	BurstableQoS = "Burstable"
+	// BestEffortQoS is the BestEffort QoS class.
+	BestEffortQoS = "BestEffort"
+)
+
+// ResourceConfig holds information about all the supported cgroup resource parameters.
+type ResourceConfig struct {
+	// Memory limit (in bytes).
+	Memory int64 `json:"memory"`
+	// CPU shares (relative weight vs. other containers).
+	CpuShares int64 `json:"cpu_shares"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	CpuQuota int64 `json:"cpu_quota"`
+}
+
+// CgroupConfig holds the cgroup configuration Information.
+// This is common object which is used to specify
+// cgroup information to both systemd and raw cgroup fs
+// implementation of the Cgroup Manager interface.
+type CgroupConfig struct {
+	// Cgroup or slice Name.
+	Name string
+	// name of parent cgroup or slice.
+	Parent string
+	// ResourceParameters contains various cgroups settings to apply.
+	ResourceParameters *ResourceConfig
+}
+
+// CgroupManger is an interface which defines the manager which allows for cgroup management.
+// Supports Cgroup Creation , Deletion and Updates.
+type CgroupManager interface {
+	// Creates and apply the cgroup configuartions on the cgroup.
+	Create(*CgroupConfig) error
+	// Destroys the cgroup.
+	Destroy() error
+	// Update cgroup configuration.
+	Update(*CgroupConfig) error
+}


### PR DESCRIPTION
In this pull request I add library support for cgroup management in Kubernetes. This would allow us to create and destroy top level cgroups and pod cgroups.

This is my first pull request, :) So I think a lot of feedback would really help.
 @ronnielai @Random-Liu @yujuhong

@dchen1107 @derekwaynecarr I would request you to please review the design of the library and suggest changes whenever you can find some time.
