### PR TITLE
Add top level Qos Management Support with cgroupfs driver

### DIFF
--- a/pkg/kubelet/cm/cgroupfs/manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroupfs/manager_unsupported.go
@@ -1,0 +1,19 @@
+// +build !linux
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgroupfs

--- a/pkg/kubelet/cm/cgroupfs/qos_manager.go
+++ b/pkg/kubelet/cm/cgroupfs/qos_manager.go
@@ -1,0 +1,112 @@
+// +build linux
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgroupfs
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+)
+
+const (
+	defaultContainerRoot string = "/"
+)
+
+// qosContainerManagerImpl implements QOSContainerManager interface.
+// It internally uses libcontainer's cgroup manager implementation
+// for qos container creation, and updates.
+type qosContainerManagerImpl struct {
+	manager   cgroups.Manager
+	qosConfig *cm.QOSConfig
+}
+
+// Make sure that it implements the qosContainerManager interface
+var _ cm.QOSContainerManager = &qosContainerManagerImpl{}
+
+// NewQOSContainerManager is a factory method and returns a qosContainerManager object
+func NewQOSContainerManager(qosConfig *cm.QOSConfig) *qosContainerManagerImpl {
+	return &qosContainerManagerImpl{
+		manager:   &fs.Manager{},
+		qosConfig: qosConfig,
+	}
+}
+
+// Create creates the top level qos cgroup containers
+// We currently create containers for the Burstable and Best Effort containers
+// All guaranteed pods are nested under the RootContainer by default
+// Init is called only once during kubelet bootstrapping.
+func (m *qosContainerManagerImpl) Init(qosConfig *cm.QOSConfig) error {
+	// The rootContainer under which all qos containers are brought up is configurable
+	// and can be specified through the --cgroup-root flag.
+	// We default to the system root / in case no root is specified
+	rootContainerName := defaultContainerRoot
+	if qosConfig.RootContainerName != "" {
+		rootContainerName = qosConfig.RootContainerName
+	}
+	// Top level for Qos containers are created only for Burstable
+	// and Best Effort classes
+	qosClasses := [2]cm.QOSClass{cm.BurstableQOS, cm.BestEffortQOS}
+
+	// Create containers for both qos classes
+	for _, qosClass := range qosClasses {
+		// containerConfig object stores the cgroup specifications
+		containerConfig := &configs.Config{
+			Cgroups: &configs.Cgroup{
+				Name:      string(qosClass),
+				Parent:    rootContainerName,
+				Resources: &configs.Resources{},
+			},
+		}
+		//Apply(0) is a hack to create the cgroup directories for each resource
+		// subsystem. The function [cgroups.Manager.apply()] applies cgroup
+		// configuration to the process with the specified pid.
+		// It creates cgroup files for each subsytems and writes the pid
+		// in the tasks file. We use the function to create all the required
+		// cgroup files but not attach any "real" pid to the cgroup.
+		if err := m.manager.Apply(0); err != nil {
+			return fmt.Errorf("Failed to create cgroups for the %v qos class : %v", qosClass, err)
+		}
+		if err := m.manager.Set(containerConfig); err != nil {
+			return fmt.Errorf("Failed to Set container Config for the %v qos class : %v", qosClass, err)
+		}
+	}
+	return nil
+}
+
+func (m *qosContainerManagerImpl) GetContainersInfo() cm.QOSContainersInfo {
+	// qosContainersInfo object stores the absolute name of the created qos containers
+	qosContainersInfo := cm.QOSContainersInfo{}
+	rootContainerName := defaultContainerRoot
+	if m.qosConfig.RootContainerName != "" {
+		rootContainerName = m.qosConfig.RootContainerName
+	}
+	// Guaranteed container is not created so guaranteed pods are brought
+	// directly under the Root container.
+	qosContainersInfo.GuaranteedContainerName = rootContainerName
+	qosContainersInfo.BurstableContainerName = path.Join(rootContainerName, string(cm.BurstableQOS))
+	qosContainersInfo.BestEffortContainerName = path.Join(rootContainerName, string(cm.BestEffortQOS))
+	return qosContainersInfo
+}
+
+//@TODO(@dubstack)
+// func (m *qosContainerManagerImpl) Update() error{}

--- a/pkg/kubelet/cm/cgroupfs/qos_manager_test.go
+++ b/pkg/kubelet/cm/cgroupfs/qos_manager_test.go
@@ -1,0 +1,61 @@
+// +build linux
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgroupfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+)
+
+// TestGetContainersInfo
+func TestGetContainersInfo(t *testing.T) {
+	cases := []struct {
+		qosConfig     *cm.QOSConfig
+		expectedValue cm.QOSContainersInfo
+	}{
+		{
+			qosConfig: &cm.QOSConfig{
+				RootContainerName: "",
+			},
+			expectedValue: cm.QOSContainersInfo{
+				GuaranteedContainerName: "/",
+				BurstableContainerName:  "/Burstable",
+				BestEffortContainerName: "/BestEffort",
+			},
+		},
+		{
+			qosConfig: &cm.QOSConfig{
+				RootContainerName: "/root-container",
+			},
+			expectedValue: cm.QOSContainersInfo{
+				GuaranteedContainerName: "/root-container",
+				BurstableContainerName:  "/root-container/Burstable",
+				BestEffortContainerName: "/root-container/BestEffort",
+			},
+		},
+	}
+	as := assert.New(t)
+	for idx, tc := range cases {
+		c := NewQOSContainerManager(tc.qosConfig)
+		actual := c.GetContainersInfo()
+		as.Equal(tc.expectedValue, actual, "expected test case [%d] to return %q; got %q instead", idx, tc.expectedValue, actual)
+	}
+}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+// QOSClass defines the supported qos classes of Pods/Containers.
+type QOSClass string
+
+//TODO(dubstack) Move this to qos package use a common definition
+// in both qos and cm package
+const (
+	// GuaranteedQOS is the Guaranteed qos class.
+	GuaranteedQOS QOSClass = "Guaranteed"
+	// BurstableQOS is the Burstable qos class.
+	BurstableQOS QOSClass = "Burstable"
+	// BestEffortQOS is the BestEffort qos class.
+	BestEffortQOS QOSClass = "BestEffort"
+)
+
+// QOSConfig defines how the qos cgroup hierarchy is organized
+type QOSConfig struct {
+	// RootContainerName is the root for the qos hierarchy
+	RootContainerName string
+}
+
+// QOSContainersInfo defines the names of containers per qos
+type QOSContainersInfo struct {
+	GuaranteedContainerName string
+	BestEffortContainerName string
+	BurstableContainerName  string
+}
+
+// QOSContainerManager stores and manages top level qos containers
+// Currently its used to create top level qos containers for the Burstable
+// and Best Effort qos classes during kubelet bootstrapping.
+// We don't have a separate qos class for the Guaranteed qos.
+// Guaranteed pods are nested under the RootContainer by default.
+type QOSContainerManager interface {
+	// Init interfaces with host OS to define
+	// qos specific containers per convention
+	Init(config *QOSConfig) error
+
+	// @TODO(dubstack) support updates to the Qos containers
+	// Update() error
+
+	// GetContainerInfo returns the top level qos containers names.
+	// The top level qos container names are different depending
+	// upon the driver (systemd or cgroupfs)
+	GetContainersInfo() QOSContainersInfo
+}


### PR DESCRIPTION
I have decided to break down my work into really small PR's. So this first one only adds support for top level QOS container management using a cgroupfs driver
Work that still needs to be done in this PR:
1. Test the Init method of the QOSContainerManager
(I was not sure how exactly to test this at this point. Later on I plan to have an e2e test to test this behaviour. Suggestions??) 
2. Move QOSClass to qos/types.go 
(Ideally if this is moved to qos package it should be used in the QOS package aswell, currently we have QOS classes defined as string constants in qos/util. I would prefer @vishh or @derekwaynecarr to confirm before I make the changes)(Should I move it to qos/util package because moving it to qos package would result in import cycles)
3. Add support for updates on the top level container. We will have a Update() method in QOSContainerManager
(This will be handled in a future PR)

I will have the PodCgroupManager implementation in a separate PR. I am currently writing tests for the same.
@ronnielai @Random-Liu @yujuhong Please have a look whenever you find time.
